### PR TITLE
Timeout Delay For "released" vesion updated

### DIFF
--- a/PROBot/Scripting/LuaScript.cs
+++ b/PROBot/Scripting/LuaScript.cs
@@ -17,7 +17,7 @@ namespace PROBot.Scripting
 #if DEBUG
         public int TimeoutDelay = 60000;
 #else
-        public int TimeoutDelay = 3000;
+        public int TimeoutDelay = 60000;
 #endif
 
         private Script _lua;


### PR DESCRIPTION
the reason is if you use a released version the script will end/close dialog in 3 sec
now should have more then enough time for map selection

(changes only effect "Released" version NOT "Debug" version)